### PR TITLE
Update on new data format

### DIFF
--- a/heatload/heatload_calc.cpp
+++ b/heatload/heatload_calc.cpp
@@ -1,4 +1,6 @@
 #include <vector>
+#include <iostream>
+#include <stdio.h>
 
 #include "particles.hpp"
 #include "flags.hpp"
@@ -11,7 +13,10 @@ extern Particle search(t_ParticleDB &db, int timestep, long long gid);
 // get heatload of single species
 void heatload_calc(const Particles &div, HeatLoad &sp, t_ParticleDB &db) {
     
+    printf ("\nHeatload calc particle size: %d\n", div.size());
     for(int i=0; i<div.size(); i++) {
+        if ((i+1)%100==0) std::cerr << ".";
+        if ((i+1)%5000==0) std::cerr << std::endl << i+1;
 
         struct Particle p = div[i]; // particle that hit divertor
         double en = sml.c2_2m * p.rho * p.rho * p.B * p.B + p.mu*p.B;

--- a/heatload/load.cpp
+++ b/heatload/load.cpp
@@ -81,8 +81,8 @@ adios2::StepStatus load_data(Particles &idiv, Particles &ediv, t_ParticlesList &
         reader.Get<float>(var_ephase, ephase);
         reader.EndStep();
 
-        assert(iphase.size() / igid.size() == 9);
-        assert(ephase.size() / egid.size() == 9);
+        assert(iphase.size() / igid.size() == NPHASE);
+        assert(ephase.size() / egid.size() == NPHASE);
 
         // populate particles
         for (int i = 0; i < igid.size(); i++)

--- a/heatload/main.cpp
+++ b/heatload/main.cpp
@@ -54,7 +54,7 @@ void heatload() {
     init();
 
     // init adios
-    load_init("xgc.escaped_ptls.su455.bp");
+    load_init("xgc.escaped_ptls.bp");
 
     t_ParticleDB iesc_db; 
     t_ParticleDB eesc_db; 


### PR DESCRIPTION
Minor fixes to follow the recent `xgc.escaped_ptls.bp` format:
My example data is here: `/gpfs/alpine/proj-shared/csc143/jyc/summit/test_GB_small_su455/xgc.escaped_ptls.bp`