### PR TITLE
Optimizing heatload

### DIFF
--- a/heatload/heatload_calc.cpp
+++ b/heatload/heatload_calc.cpp
@@ -19,7 +19,6 @@
 #include "cam_timers.hpp"
 
 extern Simulation sml;
-extern Particle search(t_ParticleDB &db, int timestep, long long gid);
 
 static long int _progress_step_current = 0;
 void progress_step(long int total)
@@ -40,23 +39,23 @@ void heatload_calc(const Particles &div, HeatLoad &sp, t_ParticleDB &db)
     LOG << "Heatload calc div particle size " << div.size();
     // reset progress bar
     _progress_step_current = 0;
-    // std::time_t start = std::time(nullptr);
 #pragma omp parallel for default(none) shared(sml, div, db, sp, std::cerr)
     for (int i = 0; i < div.size(); i++)
     {
+        /* This is very expensive...
         if (true)
         {
 #pragma omp critical
             {
                 progress_step(div.size());
             }
-        }
+        }*/
 
         struct Particle p = div[i]; // particle that hit divertor
         double en = sml.c2_2m[sp.isp] * p.rho * p.rho * p.B * p.B + p.mu * p.B;
         double wp = p.dw * p.w0;
 
-        struct Particle p_esc = search(db, p.esc_step, p.gid); // particle info when it escaped.
+        struct Particle& p_esc = search(db, p.esc_step, p.gid); // particle info when it escaped.
         // printf("%lld %d\n", p.gid, p.esc_step);
         if (p_esc.gid > 0)
         {

--- a/heatload/particles.cpp
+++ b/heatload/particles.cpp
@@ -14,16 +14,15 @@
 #define GET(X, i, j) X[i * NPHASE + j]
 
 // esc_step is 1-based index. zero means no data in the DB
-Particle search(t_ParticleDB &db, int timestep, long long gid)
+Particle& search(t_ParticleDB &db, int timestep, long long gid)
 {
+    static Particle none;
     if (db.count(timestep))
     {
         return db[timestep][gid];
     }
     else
     {
-        struct Particle none;
-        none.gid = 0;
         return none;
     }
     // return db[timestep][gid];
@@ -351,7 +350,7 @@ void ptlmap_sync(t_ParticlesList &pmap, MPI_Comm comm)
 
 void ptls_shift(Particles &ptls, Particles &ptls_from_right, MPI_Comm comm)
 {
-    TIMER_START("PTLS_SHIFT");    
+    TIMER_START("PTLS_SHIFT");
     assert(ptls_from_right.empty());
 
     int rank, comm_size;

--- a/heatload/particles.hpp
+++ b/heatload/particles.hpp
@@ -29,6 +29,7 @@ struct Particle
     long long gid;
     int flag;
     int esc_step;
+    Particle() : gid(0) {}
 };
 
 typedef std::vector<struct Particle> Particles;
@@ -37,7 +38,7 @@ typedef std::unordered_map<long long, struct Particle> t_ParticlesList;
 typedef std::map<int, t_ParticlesList> t_ParticleDB;
 
 void set_nbin(uint64_t nbin);
-Particle search(t_ParticleDB &db, int timestep, long long int gid);
+Particle& search(t_ParticleDB &db, int timestep, long long int gid);
 void add(t_ParticlesList &pmap, Particle ptl);
 void ptldb_save(t_ParticleDB &db, std::string filename, MPI_Comm comm);
 void ptldb_load(t_ParticleDB &db, std::string filename, MPI_Comm comm);


### PR DESCRIPTION
Two small but significant optimizations to reduce the HEATLOAD_CALC time from 156.261459 seconds to 9.129382 seconds for the 1024 node case.  One change is to remove a critical section around a debug message, and the other is to add a default constructor that initializes `gid` to 0, and return a static reference to a "none" particle when the search routine doesn't find the particle instead of allocating a new one, and sending back a copy.