### PR TITLE
Updating analysis for use in workflow with TAU

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ module load python/3.8-anaconda3
 module load libfabric/1.12.1-sysrdma
 
 ADIOS_DIR=/gpfs/alpine/world-shared/phy122/lib/install/summit/adios2/devel/gcc9.1.0
-CAMTIMER_DIR=/gpfs/alpine/world-shared/phy122/lib/install/summit/camtimers/gcc9.1.0
+CAMTIMER_DIR=/gpfs/alpine/world-shared/phy122/lib/install/summit/camtimers-perfstubs-nompi/gcc9.3.0
 
 CC=gcc CXX=g++ cmake -DCMAKE_PREFIX_PATH="$ADIOS_DIR;$CAMTIMER_DIR" ..
 
@@ -109,10 +109,26 @@ jsrun -n $((JOBSIZE*NR)) python adios2-panout.py --npanout=6 $XGCDIR/xgc.3d.bp x
 echo "Done."
 
 ```
+# Run with TAU:
+```
+export PATH=/gpfs/alpine/proj-shared/fus123/khuck/XGC_analysis/tau/tau2/ibm64linux/bin:$PATH
+module unload darshan-runtime
+export TAU_METRICS="TIME,PAPI_FP_OPS,PAPI_TOT_INS"
+
+echo "Run diffusion"
+jsrun -n $((JOBSIZE*NR)) -a1 -c1 -g0 -r$NR -brs /usr/bin/stdbuf -oL -eL \
+tau_exec -T xgc_analysis_mpi -monitoring -adios2 \
+./diffusion/diffusion -w $XGCDIR 2>&1 | tee run-diffusion-$JOBID.log
+
+echo "Run heatload"
+jsrun -n $((JOBSIZE*NR)) -a1 -c7 -g0 -r$NR -brs /usr/bin/stdbuf -oL -eL \
+tau_exec -T xgc_analysis_mpi -monitoring -adios2 \
+./heatload/heatload -w $XGCDIR -f 2>&1 | tee run-heatload-$JOBID.log
+```
 
 # Additional Input files for Gordon Bell
 located at
 ```
 /gpfs/alpine/world-shared/phy122/sku/GB_XGC_input
 ```
-sml_input_dir in 'input' should point this directory 
+sml_input_dir in 'input' should point this directory

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ module load python/3.8-anaconda3
 module load libfabric/1.12.1-sysrdma
 
 ADIOS_DIR=/gpfs/alpine/world-shared/phy122/lib/install/summit/adios2/devel/gcc9.1.0
-CAMTIMER_DIR=/gpfs/alpine/world-shared/phy122/lib/install/summit/camtimers-perfstubs-nompi/gcc9.3.0
+CAMTIMER_DIR=/gpfs/alpine/world-shared/phy122/lib/install/summit/camtimers-perfstubs-mpi/gcc9.3.0
 
 CC=gcc CXX=g++ cmake -DCMAKE_PREFIX_PATH="$ADIOS_DIR;$CAMTIMER_DIR" ..
 

--- a/diffusion/diffusion_main.cpp
+++ b/diffusion/diffusion_main.cpp
@@ -110,7 +110,9 @@ int main(int argc, char *argv[])
             std::cout << "Input stream had errors. Exit loop" << std::endl;
             break;
         }
-
+#ifdef CAM_TIMERS
+        TIMER_DUMP();
+#endif
         istep++;
         if ((maxstep > 0) && (istep > maxstep))
             break;

--- a/heatload/main.cpp
+++ b/heatload/main.cpp
@@ -34,6 +34,8 @@ void init_log(int rank)
     boost::log::add_console_log(std::cout, boost::log::keywords::format = fmt, boost::log::keywords::auto_flush = true);
 
     boost::log::add_common_attributes();
+    boost::log::core::get()->set_filter (
+        boost::log::trivial::severity >= boost::log::trivial::info);
 }
 
 int main(int argc, char *argv[])
@@ -107,7 +109,9 @@ int main(int argc, char *argv[])
         else if (ret == -1)
             // no more data
             break;
-
+#ifdef CAM_TIMERS
+        TIMER_DUMP();
+#endif
         istep++;
         if ((maxstep > 0) && (istep > maxstep))
             break;

--- a/poincare/README.md
+++ b/poincare/README.md
@@ -7,7 +7,10 @@ module load git-lfs
 module load gcc/9.1.0
 module load cuda/11.0.3
 module load cmake/3.21.3
-module load adios2
+module load libfabric/1.12.1-sysrdma  # needed by adios
+
+# Use the ADIOS for XGC
+export ADIOS_DIR=/gpfs/alpine/world-shared/phy122/lib/install/summit/adios2/devel/gcc9.1.0
 
 mkdir build
 cd build
@@ -23,7 +26,7 @@ cmake \
  -DVTKm_ENABLE_CUDA=ON \
  -DVTKm_ENABLE_OPENMP=ON \
  -DVTKm_ENABLE_MPI=OFF \
- -DADIOS2_DIR=/sw/summit/spack-envs/base/opt/linux-rhel8-ppc64le/gcc-7.5.0/adios2-2.7.1-qtvhwjxzdlbro3zv7zytmxm72fc3a5d5/lib64/cmake/adios2 \
+ -DADIOS2_DIR=${ADIOS_DIR}/lib64/cmake/adios2 \
  -DVTKm_USE_DOUBLE_PRECISION=ON \
 ../vtk-m
 
@@ -51,6 +54,6 @@ Running on whoopingcough:
 
 ./examples/poincare/Poincare --dir /media/dpn/disk2TB/proj/vtkm/XGCLocator/data/XGC_GB/su458_ITER_data --useHighOrder --turbulence 1 --openmp  --output OUT --numPunc 100 --gpuParams 256 128 --stepSize 0.01 --dumpSeeds --parseAdios xgc.particle.0000000.init.bp 1 |tee out
 
-
-
 ```
+
+Note: poincare has been updated to include the perfstubs timers.  These timers will link automatically with TAU when the analysis is run with tau_exec.

--- a/poincare/vtk-m/examples/poincare/CMakeLists.txt
+++ b/poincare/vtk-m/examples/poincare/CMakeLists.txt
@@ -19,11 +19,13 @@ set(Poincare_srcs
  FindMaxR.cxx
  RunPoincare2.cxx
  EvalField.cxx
+ perfstubs_api/timer.c
  )
 
 add_executable(Poincare ${Poincare_srcs})
 
 target_link_libraries(Poincare PRIVATE vtkm_cont vtkm_worklet vtkm_io adios2::adios2)
+target_include_directories(Poincare PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
 vtkm_add_target_information(Poincare
                             DROP_UNUSED_SYMBOLS MODIFY_CUDA_FLAGS

--- a/poincare/vtk-m/examples/poincare/Poincare.cxx
+++ b/poincare/vtk-m/examples/poincare/Poincare.cxx
@@ -69,6 +69,8 @@ std::map<std::string, adiosS*> adiosStuff;
 #include "ComputeBCell.h"
 #endif
 
+#include "perfstubs_api/timer.h"
+
 template <typename T>
 std::ostream& operator<< (std::ostream& out, const std::vector<T>& v)
 {
@@ -224,6 +226,7 @@ ReadScalar(adiosS* stuff,
            bool add3D=false,
            bool addExtra=false)
 {
+  PERFSTUBS_SCOPED_TIMER_FUNC();
   if (fileName.empty())
     fileName = vname;
 
@@ -261,6 +264,7 @@ ReadB(adiosS* stuff,
       XGCParameters& xgcParams,
       vtkm::cont::DataSet& ds)
 {
+  PERFSTUBS_SCOPED_TIMER_FUNC();
   std::string fileName = "/node_data[0]/values";
 
   auto Bvar = stuff->io.InquireVariable<double>(fileName);
@@ -284,6 +288,7 @@ ReadPsiInterp(adiosS* eqStuff,
               XGCParameters& xgcParams,
               std::map<std::string, std::vector<std::string>>& args)
 {
+  PERFSTUBS_SCOPED_TIMER_FUNC();
   eqStuff->engine.Get(eqStuff->io.InquireVariable<int>("eq_mr"), &xgcParams.eq_mr, adios2::Mode::Sync);
   eqStuff->engine.Get(eqStuff->io.InquireVariable<int>("eq_mz"), &xgcParams.eq_mz, adios2::Mode::Sync);
   eqStuff->engine.Get(eqStuff->io.InquireVariable<double>("eq_axis_r"), &xgcParams.eq_axis_r, adios2::Mode::Sync);
@@ -460,6 +465,7 @@ ReadPsiInterp(adiosS* eqStuff,
 vtkm::cont::DataSet
 ReadMesh(adiosS* meshStuff, XGCParameters& xgcParams)
 {
+  PERFSTUBS_SCOPED_TIMER_FUNC();
   std::vector<double> rz;
   std::vector<int> conn, nextnode;
   meshStuff->engine.Get(meshStuff->io.InquireVariable<double>("/coordinates/values"), rz, adios2::Mode::Sync);
@@ -498,6 +504,7 @@ ReadMesh(adiosS* meshStuff, XGCParameters& xgcParams)
 vtkm::cont::DataSet
 ReadMesh3D(adiosS* meshStuff, bool addExtra, XGCParameters& xgcParams)
 {
+  PERFSTUBS_SCOPED_TIMER_FUNC();
   std::vector<double> rz;
   std::vector<int> conn, nextnode;
   meshStuff->engine.Get(meshStuff->io.InquireVariable<double>("/coordinates/values"), rz, adios2::Mode::Sync);
@@ -579,6 +586,7 @@ SaveOutput(const std::vector<std::vector<vtkm::Vec3f>>& traces,
            const std::string& outFileName = "",
            int timeStep=0)
 {
+  PERFSTUBS_SCOPED_TIMER_FUNC();
   std::string tracesNm, puncNm, puncThetaPsiNm, adiosNm;
   if (outFileName.empty())
   {
@@ -707,6 +715,7 @@ Poincare(const vtkm::cont::DataSet& ds,
          std::map<std::string, std::vector<std::string>>& args,
          int timeStep=0)
 {
+  PERFSTUBS_SCOPED_TIMER_FUNC();
   vtkm::cont::ArrayHandle<vtkm::FloatDefault> As_ff, coeff_1D, coeff_2D, psi;
   vtkm::cont::ArrayHandle<vtkm::Vec3f> B_rzp, B_Norm_rzp, dAs_ff_rzp;
   //ds.GetField("As_phi_ff").GetData().AsArrayHandle(As_ff);
@@ -770,6 +779,7 @@ Poincare(const vtkm::cont::DataSet& ds,
 vtkm::cont::ArrayHandle<vtkm::FloatDefault>
 CalcAs(const vtkm::cont::ArrayHandle<vtkm::FloatDefault>& As, XGCParameters& xgcParams)
 {
+  PERFSTUBS_SCOPED_TIMER_FUNC();
 //  vtkm::cont::ArrayHandle<vtkm::FloatDefault> As;
 
 //  ds.GetField("As_phi_ff").GetData().AsArrayHandle(As);
@@ -833,6 +843,7 @@ CalcAs(const vtkm::cont::ArrayHandle<vtkm::FloatDefault>& As, XGCParameters& xgc
 vtkm::cont::ArrayHandle<vtkm::Vec3f>
 Calc_dAs(const vtkm::cont::ArrayHandle<vtkm::FloatDefault>& dAsAH, XGCParameters& xgcParams)
 {
+  PERFSTUBS_SCOPED_TIMER_FUNC();
   //Assumed that dAs_phi_ff is R,Z,Phi
   //vtkm::cont::ArrayHandle<vtkm::FloatDefault> dAsAH;
   //ds.GetField("dAs_phi_ff").GetData().AsArrayHandle(dAsAH);
@@ -937,6 +948,7 @@ UpdateField(vtkm::cont::DataSet& ds,
             const std::string& vName,
             vtkm::cont::ArrayHandle<T> &var)
 {
+  PERFSTUBS_SCOPED_TIMER_FUNC();
   if (ds.HasField(vName))
   {
     vtkm::cont::ArrayHandle<T> oldVar;
@@ -956,6 +968,7 @@ ReadTurbData(adiosS* turbStuff,
              vtkm::cont::ArrayHandle<vtkm::FloatDefault>& As_arr,
              vtkm::cont::ArrayHandle<vtkm::FloatDefault>& dAs_arr)
 {
+  PERFSTUBS_SCOPED_TIMER_FUNC();
   auto asV = turbStuff->io.InquireVariable<double>("As_phi_ff");
   auto dAsV = turbStuff->io.InquireVariable<double>("dAs_phi_ff");
 
@@ -987,6 +1000,7 @@ ReadStaticData(std::map<std::string, std::vector<std::string>>& args,
                XGCParameters& xgcParams,
                const std::string& coeffFile)
 {
+  PERFSTUBS_SCOPED_TIMER_FUNC();
   if (adios != nullptr)
   {
     std::cerr<<"Re-reading static data!!!"<<std::endl;
@@ -1053,6 +1067,7 @@ ReadStaticData(std::map<std::string, std::vector<std::string>>& args,
 vtkm::cont::DataSet
 ReadDataSet_ORIG(std::map<std::string, std::vector<std::string>>& args, XGCParameters& xgcParams)
 {
+  PERFSTUBS_SCOPED_TIMER_FUNC();
   auto ds = ReadStaticData(args, xgcParams, "xgc.bfield-all.bp");
 
   //Get the data...
@@ -1087,6 +1102,7 @@ ReadDataSet_ORIG(std::map<std::string, std::vector<std::string>>& args, XGCParam
 vtkm::cont::DataSet
 ReadDataSet(std::map<std::string, std::vector<std::string>>& args, XGCParameters& xgcParams)
 {
+  PERFSTUBS_SCOPED_TIMER_FUNC();
   vtkm::cont::DataSet ds;
 
   if (args.find("--test") != args.end())
@@ -1703,6 +1719,7 @@ GenerateSeeds(const vtkm::cont::DataSet& ds,
 void
 StreamingPoincare(std::map<std::string, std::vector<std::string>>& args)
 {
+  PERFSTUBS_SCOPED_TIMER_FUNC();
   XGCParameters xgcParams;
 
   std::map<std::string, std::string> adiosArgs;
@@ -1764,7 +1781,7 @@ StreamingPoincare(std::map<std::string, std::vector<std::string>>& args)
 
     std::cout<<"Dump to "<<outputFile<<std::endl;
     Poincare(ds, xgcParams, seedsCopy, args, timeStep);
-
+    PERFSTUBS_DUMP_DATA();
     step++;
   }
 }
@@ -1772,6 +1789,8 @@ StreamingPoincare(std::map<std::string, std::vector<std::string>>& args)
 int
 main(int argc, char** argv)
 {
+  PERFSTUBS_INITIALIZE();
+  PERFSTUBS_SCOPED_TIMER_FUNC();
   MPI_Init(&argc, &argv);
   int rank, numRanks;
   MPI_Comm_size(MPI_COMM_WORLD, &numRanks);
@@ -1897,6 +1916,8 @@ main(int argc, char** argv)
   for (auto& i : adiosStuff)
     delete i.second;
 
+  PERFSTUBS_FINALIZE();
+  MPI_Finalize();
   return 0;
 }
 

--- a/poincare/vtk-m/examples/poincare/RunPoincare2.cxx
+++ b/poincare/vtk-m/examples/poincare/RunPoincare2.cxx
@@ -5,6 +5,7 @@
 #include "RunPoincare2.h"
 #include "Poincare2.h"
 
+#include "perfstubs_api/timer.h"
 
 void
 RunPoincare2(const vtkm::cont::DataSet& ds,
@@ -22,6 +23,7 @@ RunPoincare2(const vtkm::cont::DataSet& ds,
              vtkm::cont::ArrayHandle<vtkm::Vec2f>& outTP,
              vtkm::cont::ArrayHandle<vtkm::Id>& outID)
 {
+  PERFSTUBS_SCOPED_TIMER_FUNC();
   //Get all the arguments...
   vtkm::FloatDefault stepSize = std::atof(args["--stepSize"][0].c_str());
   vtkm::Id numPunc = std::atoi(args["--numPunc"][0].c_str());

--- a/poincare/vtk-m/examples/poincare/perfstubs_api/config.h
+++ b/poincare/vtk-m/examples/poincare/perfstubs_api/config.h
@@ -1,0 +1,9 @@
+// the configured options and settings for Tutorial
+// Copyright (c) 2019-2020 University of Oregon
+// Distributed under the BSD Software License
+// (See accompanying file LICENSE.txt)
+#define PerfStubs_VERSION_MAJOR 0
+#define PerfStubs_VERSION_MINOR 1
+#define PERFSTUBS_USE_TIMERS
+//#define PERFSTUBS_USE_STATIC
+

--- a/poincare/vtk-m/examples/poincare/perfstubs_api/timer.c
+++ b/poincare/vtk-m/examples/poincare/perfstubs_api/timer.c
@@ -1,0 +1,448 @@
+// Copyright (c) 2019-2020 University of Oregon
+// Distributed under the BSD Software License
+// (See accompanying file LICENSE.txt)
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE // needed to define RTLD_DEFAULT
+#endif
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <dlfcn.h>
+#include "pthread.h"
+#ifndef PERFSTUBS_USE_TIMERS
+#define PERFSTUBS_USE_TIMERS
+#endif
+#include "perfstubs_api/timer.h"
+
+#define MAX_TOOLS 1
+
+/* Make sure that the Timer singleton is constructed when the
+ * library is loaded.  This will ensure (on linux, anyway) that
+ * we can assert that we have m_Initialized on the main thread. */
+//static void __attribute__((constructor)) initialize_library(void);
+
+/* Globals for the plugin API */
+
+int perfstubs_initialized = PERFSTUBS_UNKNOWN;
+int num_tools_registered = 0;
+/* Keep track of whether the thread has been registered */
+/* __thread int thread_seen = 0; */
+/* Implemented with PGI-friendly implementation, they can't be bothered
+ * to implement the thread_local standard like every other compiler... */
+static pthread_key_t key;
+static pthread_once_t key_once = PTHREAD_ONCE_INIT;
+
+static void make_key(void) {
+    (void) pthread_key_create(&key, NULL);
+}
+
+/* Function pointers */
+
+ps_initialize_t initialize_functions[MAX_TOOLS];
+ps_finalize_t finalize_functions[MAX_TOOLS];
+ps_pause_measurement_t pause_measurement_functions[MAX_TOOLS];
+ps_resume_measurement_t resume_measurement_functions[MAX_TOOLS];
+ps_register_thread_t register_thread_functions[MAX_TOOLS];
+ps_dump_data_t dump_data_functions[MAX_TOOLS];
+ps_timer_create_t timer_create_functions[MAX_TOOLS];
+ps_timer_start_t timer_start_functions[MAX_TOOLS];
+ps_timer_stop_t timer_stop_functions[MAX_TOOLS];
+ps_start_string_t start_string_functions[MAX_TOOLS];
+ps_stop_string_t stop_string_functions[MAX_TOOLS];
+ps_stop_current_t stop_current_functions[MAX_TOOLS];
+ps_set_parameter_t set_parameter_functions[MAX_TOOLS];
+ps_dynamic_phase_start_t dynamic_phase_start_functions[MAX_TOOLS];
+ps_dynamic_phase_stop_t dynamic_phase_stop_functions[MAX_TOOLS];
+ps_create_counter_t create_counter_functions[MAX_TOOLS];
+ps_sample_counter_t sample_counter_functions[MAX_TOOLS];
+ps_set_metadata_t set_metadata_functions[MAX_TOOLS];
+ps_get_timer_data_t get_timer_data_functions[MAX_TOOLS];
+ps_get_counter_data_t get_counter_data_functions[MAX_TOOLS];
+ps_get_metadata_t get_metadata_functions[MAX_TOOLS];
+ps_free_timer_data_t free_timer_data_functions[MAX_TOOLS];
+ps_free_counter_data_t free_counter_data_functions[MAX_TOOLS];
+ps_free_metadata_t free_metadata_functions[MAX_TOOLS];
+
+#ifdef PERFSTUBS_USE_STATIC
+
+#if defined(__clang__) && defined(__APPLE__)
+#define PS_WEAK_PRE
+#define PS_WEAK_POST __attribute__((weak_import))
+#define PS_WEAK_POST_NULL __attribute__((weak_import))
+#else
+#define PS_WEAK_PRE __attribute__((weak))
+#define PS_WEAK_POST
+#define PS_WEAK_POST_NULL
+#endif
+
+PS_WEAK_PRE void ps_tool_initialize(void) PS_WEAK_POST;
+PS_WEAK_PRE void ps_tool_finalize(void) PS_WEAK_POST;
+PS_WEAK_PRE void ps_tool_pause_measurement(void) PS_WEAK_POST;
+PS_WEAK_PRE void ps_tool_resume_measurement(void) PS_WEAK_POST;
+PS_WEAK_PRE void ps_tool_register_thread(void) PS_WEAK_POST;
+PS_WEAK_PRE void ps_tool_dump_data(void) PS_WEAK_POST;
+PS_WEAK_PRE void* ps_tool_timer_create(const char *) PS_WEAK_POST;
+PS_WEAK_PRE void ps_tool_timer_start(void *) PS_WEAK_POST;
+PS_WEAK_PRE void ps_tool_timer_stop(void *) PS_WEAK_POST;
+PS_WEAK_PRE void ps_tool_start_string(const char *) PS_WEAK_POST;
+PS_WEAK_PRE void ps_tool_stop_string(const char *) PS_WEAK_POST;
+PS_WEAK_PRE void ps_tool_stop_current(void) PS_WEAK_POST;
+PS_WEAK_PRE void ps_tool_set_parameter(const char *, int64_t) PS_WEAK_POST;
+PS_WEAK_PRE void ps_tool_dynamic_phase_start(const char *, int) PS_WEAK_POST;
+PS_WEAK_PRE void ps_tool_dynamic_phase_stop(const char *, int) PS_WEAK_POST;
+PS_WEAK_PRE void* ps_tool_create_counter(const char *) PS_WEAK_POST;
+PS_WEAK_PRE void ps_tool_sample_counter(void *, double) PS_WEAK_POST;
+PS_WEAK_PRE void ps_tool_set_metadata(const char *, const char *) PS_WEAK_POST;
+PS_WEAK_PRE void ps_tool_get_timer_data(ps_tool_timer_data_t *) PS_WEAK_POST;
+PS_WEAK_PRE void ps_tool_get_counter_data(ps_tool_counter_data_t *) PS_WEAK_POST;
+PS_WEAK_PRE void ps_tool_get_metadata(ps_tool_metadata_t *) PS_WEAK_POST;
+PS_WEAK_PRE void ps_tool_free_timer_data(ps_tool_timer_data_t *) PS_WEAK_POST;
+PS_WEAK_PRE void ps_tool_free_counter_data(ps_tool_counter_data_t *) PS_WEAK_POST;
+PS_WEAK_PRE void ps_tool_free_metadata(ps_tool_metadata_t *) PS_WEAK_POST;
+#endif
+
+void initialize_library() {
+#ifdef PERFSTUBS_USE_STATIC
+    /* The initialization function is the only required one */
+    initialize_functions[0] = &ps_tool_initialize;
+    if (initialize_functions[0] == NULL) {
+        perfstubs_initialized = PERFSTUBS_FAILURE;
+        return;
+    }
+    printf("Found ps_tool_initialize(), registering tool\n");
+    finalize_functions[0] = &ps_tool_finalize;
+    pause_measurement_functions[0] = &ps_tool_pause_measurement;
+    resume_measurement_functions[0] = &ps_tool_resume_measurement;
+    register_thread_functions[0] = &ps_tool_register_thread;
+    dump_data_functions[0] = &ps_tool_dump_data;
+    timer_create_functions[0] = &ps_tool_timer_create;
+    timer_start_functions[0] = &ps_tool_timer_start;
+    timer_stop_functions[0] = &ps_tool_timer_stop;
+    start_string_functions[0] = &ps_tool_start_string;
+    stop_string_functions[0] = &ps_tool_stop_string;
+    stop_current_functions[0] = &ps_tool_stop_current;
+    set_parameter_functions[0] = &ps_tool_set_parameter;
+    dynamic_phase_start_functions[0] = &ps_tool_dynamic_phase_start;
+    dynamic_phase_stop_functions[0] = &ps_tool_dynamic_phase_stop;
+    create_counter_functions[0] = &ps_tool_create_counter;
+    sample_counter_functions[0] = &ps_tool_sample_counter;
+    set_metadata_functions[0] = &ps_tool_set_metadata;
+    get_timer_data_functions[0] = &ps_tool_get_timer_data;
+    get_counter_data_functions[0] = &ps_tool_get_counter_data;
+    get_metadata_functions[0] = &ps_tool_get_metadata;
+    free_timer_data_functions[0] = &ps_tool_free_timer_data;
+    free_counter_data_functions[0] = &ps_tool_free_counter_data;
+    free_metadata_functions[0] = &ps_tool_free_metadata;
+#else
+    initialize_functions[0] =
+        (ps_initialize_t)dlsym(RTLD_DEFAULT, "ps_tool_initialize");
+    if (initialize_functions[0] == NULL) {
+        perfstubs_initialized = PERFSTUBS_FAILURE;
+        return;
+    }
+    printf("Found ps_tool_initialize(), registering tool\n");
+    finalize_functions[0] =
+        (ps_finalize_t)dlsym(RTLD_DEFAULT, "ps_tool_finalize");
+    pause_measurement_functions[0] =
+        (ps_pause_measurement_t)dlsym(RTLD_DEFAULT, "ps_tool_pause_measurement");
+    resume_measurement_functions[0] =
+        (ps_resume_measurement_t)dlsym(RTLD_DEFAULT, "ps_tool_resume_measurement");
+    register_thread_functions[0] =
+        (ps_register_thread_t)dlsym(RTLD_DEFAULT, "ps_tool_register_thread");
+    dump_data_functions[0] =
+        (ps_dump_data_t)dlsym(RTLD_DEFAULT, "ps_tool_dump_data");
+    timer_create_functions[0] =
+        (ps_timer_create_t)dlsym(RTLD_DEFAULT,
+        "ps_tool_timer_create");
+    timer_start_functions[0] =
+        (ps_timer_start_t)dlsym(RTLD_DEFAULT, "ps_tool_timer_start");
+    timer_stop_functions[0] =
+        (ps_timer_stop_t)dlsym(RTLD_DEFAULT, "ps_tool_timer_stop");
+    start_string_functions[0] =
+        (ps_start_string_t)dlsym(RTLD_DEFAULT, "ps_tool_start_string");
+    stop_string_functions[0] =
+        (ps_stop_string_t)dlsym(RTLD_DEFAULT, "ps_tool_stop_string");
+    stop_current_functions[0] =
+        (ps_stop_current_t)dlsym(RTLD_DEFAULT, "ps_tool_stop_current");
+    set_parameter_functions[0] =
+        (ps_set_parameter_t)dlsym(RTLD_DEFAULT, "ps_tool_set_parameter");
+    dynamic_phase_start_functions[0] = (ps_dynamic_phase_start_t)dlsym(
+        RTLD_DEFAULT, "ps_tool_dynamic_phase_start");
+    dynamic_phase_stop_functions[0] = (ps_dynamic_phase_stop_t)dlsym(
+        RTLD_DEFAULT, "ps_tool_dynamic_phase_stop");
+    create_counter_functions[0] = (ps_create_counter_t)dlsym(
+        RTLD_DEFAULT, "ps_tool_create_counter");
+    sample_counter_functions[0] = (ps_sample_counter_t)dlsym(
+        RTLD_DEFAULT, "ps_tool_sample_counter");
+    set_metadata_functions[0] =
+        (ps_set_metadata_t)dlsym(RTLD_DEFAULT, "ps_tool_set_metadata");
+    get_timer_data_functions[0] = (ps_get_timer_data_t)dlsym(
+        RTLD_DEFAULT, "ps_tool_get_timer_data");
+    get_counter_data_functions[0] = (ps_get_counter_data_t)dlsym(
+        RTLD_DEFAULT, "ps_tool_get_counter_data");
+    get_metadata_functions[0] = (ps_get_metadata_t)dlsym(
+        RTLD_DEFAULT, "ps_tool_get_metadata");
+    free_timer_data_functions[0] = (ps_free_timer_data_t)dlsym(
+        RTLD_DEFAULT, "ps_tool_free_timer_data");
+    free_counter_data_functions[0] = (ps_free_counter_data_t)dlsym(
+        RTLD_DEFAULT, "ps_tool_free_counter_data");
+    free_metadata_functions[0] = (ps_free_metadata_t)dlsym(
+        RTLD_DEFAULT, "ps_tool_free_metadata");
+#endif
+    perfstubs_initialized = PERFSTUBS_SUCCESS;
+    /* Increment the number of tools */
+    num_tools_registered = 1;
+}
+
+char * ps_make_timer_name_(const char * file,
+    const char * func, int line) {
+    /* The length of the line number as a string is floor(log10(abs(num))) */
+    int string_length = (strlen(file) + strlen(func) + (int)(floor(log10(abs(line)))) + 12);
+    char * name = (char*)calloc(string_length, sizeof(char));
+    sprintf(name, "%s [{%s} {%d,0}]", func, file, line);
+    return (name);
+}
+
+// used internally to the class
+static inline void ps_register_thread_internal(void) {
+    //if (thread_seen == 0) {
+    if (pthread_getspecific(key) == NULL) {
+    	int i;
+    	for (i = 0 ; i < num_tools_registered ; i++) {
+        	register_thread_functions[i]();
+    	}
+    	//thread_seen = 1;
+    	pthread_setspecific(key, (void*)1UL);
+    }
+}
+
+/* Initialization */
+void ps_initialize_(void) {
+    int i;
+    /* Only do this once */
+    if (perfstubs_initialized != PERFSTUBS_UNKNOWN) {
+        return;
+    }
+    initialize_library();
+    for (i = 0 ; i < num_tools_registered ; i++) {
+        initialize_functions[i]();
+    }
+    /* No need to register the main thread */
+    //thread_seen = 1;
+    (void) pthread_once(&key_once, make_key);
+    if (pthread_getspecific(key) == NULL) {
+        // set the key to 1, indicating we have seen this thread
+        pthread_setspecific(key, (void*)1UL);
+    }
+}
+
+void ps_finalize_(void) {
+    int i;
+    for (i = 0 ; i < num_tools_registered ; i++) {
+        if (finalize_functions[i] != NULL)
+            finalize_functions[i]();
+    }
+}
+
+void ps_pause_measurement_(void) {
+    int i;
+    for (i = 0 ; i < num_tools_registered ; i++) {
+        if (pause_measurement_functions[i] != NULL)
+            pause_measurement_functions[i]();
+    }
+}
+
+void ps_resume_measurement_(void) {
+    int i;
+    for (i = 0 ; i < num_tools_registered ; i++) {
+        if (resume_measurement_functions[i] != NULL)
+            resume_measurement_functions[i]();
+    }
+}
+
+void ps_register_thread_(void) {
+    ps_register_thread_internal();
+}
+
+void* ps_timer_create_(const char *timer_name) {
+	ps_register_thread_internal();
+    void ** objects = (void **)calloc(num_tools_registered, sizeof(void*));
+    int i;
+    for (i = 0 ; i < num_tools_registered ; i++) {
+        if (timer_create_functions[i] != NULL)
+            objects[i] = (void *)timer_create_functions[i](timer_name);
+    }
+    return (void*)(objects);
+}
+
+void ps_timer_create_fortran_(void ** object, const char *timer_name) {
+    *object = ps_timer_create_(timer_name);
+}
+
+void ps_timer_start_(void *timer) {
+	ps_register_thread_internal();
+    void ** objects = (void **)timer;
+    int i;
+    for (i = 0; i < num_tools_registered ; i++) {
+        if (timer_start_functions[i] != NULL &&
+            objects[i] != NULL)
+            timer_start_functions[i](objects[i]);
+    }
+}
+
+void ps_timer_start_fortran_(void **timer) {
+    ps_timer_start_(*timer);
+}
+
+void ps_timer_stop_(void *timer) {
+    void ** objects = (void **)timer;
+    int i;
+    for (i = 0; i < num_tools_registered ; i++) {
+        if (timer_stop_functions[i] != NULL &&
+            objects[i] != NULL)
+            timer_stop_functions[i](objects[i]);
+    }
+}
+
+void ps_timer_stop_fortran_(void **timer) {
+    ps_timer_stop_(*timer);
+}
+
+void ps_start_string_(const char *timer_name) {
+	ps_register_thread_internal();
+    int i;
+    for (i = 0 ; i < num_tools_registered ; i++) {
+        if (start_string_functions[i] != NULL)
+            start_string_functions[i](timer_name);
+    }
+}
+
+void ps_stop_string_(const char *timer_name) {
+    int i;
+    for (i = 0 ; i < num_tools_registered ; i++) {
+        if (stop_string_functions[i] != NULL)
+            stop_string_functions[i](timer_name);
+    }
+}
+
+void ps_stop_current_(void) {
+    int i;
+    for (i = 0 ; i < num_tools_registered ; i++) {
+        if (stop_current_functions[i] != NULL)
+            stop_current_functions[i]();
+    }
+}
+
+void ps_set_parameter_(const char * parameter_name, int64_t parameter_value) {
+    int i;
+    for (i = 0; i < num_tools_registered ; i++) {
+        if (set_parameter_functions[i] != NULL)
+            set_parameter_functions[i](parameter_name, parameter_value);
+    }
+}
+
+void ps_dynamic_phase_start_(const char *phase_prefix, int iteration_index) {
+    int i;
+    for (i = 0; i < num_tools_registered ; i++) {
+        if (dynamic_phase_start_functions[i] != NULL)
+            dynamic_phase_start_functions[i](phase_prefix, iteration_index);
+    }
+}
+
+void ps_dynamic_phase_stop_(const char *phase_prefix, int iteration_index) {
+    int i;
+    for (i = 0; i < num_tools_registered ; i++) {
+        if (dynamic_phase_stop_functions[i] != NULL)
+            dynamic_phase_stop_functions[i](phase_prefix, iteration_index);
+    }
+}
+
+void* ps_create_counter_(const char *name) {
+	ps_register_thread_internal();
+    void ** objects = (void **)calloc(num_tools_registered, sizeof(void*));
+    int i;
+    for (i = 0 ; i < num_tools_registered ; i++) {
+        if (create_counter_functions[i] != NULL)
+            objects[i] = (void*)create_counter_functions[i](name);
+    }
+    return (void*)(objects);
+}
+
+void ps_create_counter_fortran_(void ** object, const char *name) {
+    *object = ps_create_counter_(name);
+}
+
+void ps_sample_counter_(void *counter, const double value) {
+    void ** objects = (void **)counter;
+    int i;
+    for (i = 0; i < num_tools_registered ; i++) {
+        if (sample_counter_functions[i] != NULL &&
+            objects[i] != NULL)
+            sample_counter_functions[i](objects[i], value);
+    }
+}
+
+void ps_sample_counter_fortran_(void **counter, const double value) {
+    ps_sample_counter_(*counter, value);
+}
+
+void ps_set_metadata_(const char *name, const char *value) {
+	ps_register_thread_internal();
+    int i;
+    for (i = 0; i < num_tools_registered ; i++) {
+        if (set_metadata_functions[i] != NULL)
+            set_metadata_functions[i](name, value);
+    }
+}
+
+void ps_dump_data_(void) {
+    int i;
+    for (i = 0; i < num_tools_registered ; i++) {
+        if (dump_data_functions[i] != NULL)
+            dump_data_functions[i]();
+    }
+}
+
+void ps_get_timer_data_(ps_tool_timer_data_t *timer_data, int tool_id) {
+    if (tool_id < num_tools_registered) {
+        if (get_timer_data_functions[tool_id] != NULL)
+            get_timer_data_functions[tool_id](timer_data);
+    }
+}
+
+void ps_get_counter_data_(ps_tool_counter_data_t *counter_data, int tool_id) {
+    if (tool_id < num_tools_registered) {
+        if (get_counter_data_functions[tool_id] != NULL)
+            get_counter_data_functions[tool_id](counter_data);
+    }
+}
+
+void ps_get_metadata_(ps_tool_metadata_t *metadata, int tool_id) {
+    if (tool_id < num_tools_registered) {
+        if (get_metadata_functions[tool_id] != NULL)
+            get_metadata_functions[tool_id](metadata);
+    }
+}
+
+void ps_free_timer_data_(ps_tool_timer_data_t *timer_data, int tool_id) {
+    if (tool_id < num_tools_registered) {
+        if (free_timer_data_functions[tool_id] != NULL)
+            free_timer_data_functions[tool_id](timer_data);
+    }
+}
+
+void ps_free_counter_data_(ps_tool_counter_data_t *counter_data, int tool_id) {
+    if (tool_id < num_tools_registered) {
+        if (free_counter_data_functions[tool_id] != NULL)
+            free_counter_data_functions[tool_id](counter_data);
+    }
+}
+
+void ps_free_metadata_(ps_tool_metadata_t *metadata, int tool_id) {
+    if (tool_id < num_tools_registered) {
+        if (free_metadata_functions[tool_id] != NULL)
+            free_metadata_functions[tool_id](metadata);
+    }
+}
+

--- a/poincare/vtk-m/examples/poincare/perfstubs_api/timer.h
+++ b/poincare/vtk-m/examples/poincare/perfstubs_api/timer.h
@@ -1,0 +1,264 @@
+// Copyright (c) 2019-2020 University of Oregon
+// Distributed under the BSD Software License
+// (See accompanying file LICENSE.txt)
+
+#pragma once
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include "perfstubs_api/config.h"
+#include "perfstubs_api/tool.h"
+
+/* These macros help generate unique variable names within a function
+ * based on the source code line number */
+#define CONCAT_(x,y) x##y
+#define CONCAT(x,y) CONCAT_(x,y)
+
+/* ------------------------------------------------------------------ */
+/* Define the C API and PerfStubs glue class first */
+/* ------------------------------------------------------------------ */
+
+/* Pretty functions will include the return type and argument types,
+ * not just the function name.  If the compiler doesn't support it,
+ * just use the function name. */
+
+#if defined(__GNUC__)
+#define __PERFSTUBS_FUNCTION__ __PRETTY_FUNCTION__
+#else
+#define __PERFSTUBS_FUNCTION__ __func__
+#endif
+
+#define PERFSTUBS_UNKNOWN 0
+#define PERFSTUBS_SUCCESS 1
+#define PERFSTUBS_FAILURE 2
+#define PERFSTUBS_FINALIZED 3
+
+extern int perfstubs_initialized;
+
+/* ------------------------------------------------------------------ */
+/* Now define the C API */
+/* ------------------------------------------------------------------ */
+
+#if defined(PERFSTUBS_USE_TIMERS)
+
+/* regular C API */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void  ps_initialize_(void);
+void  ps_finalize_(void);
+void  ps_pause_measurement_(void);
+void  ps_resume_measurement_(void);
+void  ps_register_thread_(void);
+void  ps_dump_data_(void);
+void* ps_timer_create_(const char *timer_name);
+void  ps_timer_create_fortran_(void ** object, const char *timer_name);
+void  ps_timer_start_(void *timer);
+void  ps_timer_start_fortran_(void **timer);
+void  ps_timer_stop_(void *timer);
+void  ps_timer_stop_fortran_(void **timer);
+void  ps_start_string_(const char *timer_name);
+void  ps_stop_string_(const char *timer_name);
+void  ps_stop_current_(void);
+void  ps_set_parameter_(const char *parameter_name, int64_t parameter_value);
+void  ps_dynamic_phase_start_(const char *phasePrefix, int iterationIndex);
+void  ps_dynamic_phase_stop_(const char *phasePrefix, int iterationIndex);
+void* ps_create_counter_(const char *name);
+void  ps_create_counter_fortran_(void ** object, const char *name);
+void  ps_sample_counter_(void *counter, const double value);
+void  ps_sample_counter_fortran_(void **counter, const double value);
+void  ps_set_metadata_(const char *name, const char *value);
+
+/* data query API */
+
+void  ps_get_timer_data_(ps_tool_timer_data_t *timer_data, int tool_id);
+void  ps_get_counter_data_(ps_tool_counter_data_t *counter_data, int tool_id);
+void  ps_get_metadata_(ps_tool_metadata_t *metadata, int tool_id);
+void  ps_free_timer_data_(ps_tool_timer_data_t *timer_data, int tool_id);
+void  ps_free_counter_data_(ps_tool_counter_data_t *counter_data, int tool_id);
+void  ps_free_metadata_(ps_tool_metadata_t *metadata, int tool_id);
+
+char* ps_make_timer_name_(const char * file, const char * func, int line);
+
+#ifdef __cplusplus
+}
+#endif
+
+/* Macro API for option of entirely disabling at compile time
+ * To use this API, set the Macro PERFSTUBS_USE_TIMERS on the command
+ * line or in a config.h file, however your project does it
+ */
+
+#define PERFSTUBS_INITIALIZE() ps_initialize_();
+
+#define PERFSTUBS_FINALIZE() ps_finalize_();
+
+#define PERFSTUBS_PAUSE_MEASUREMENT() ps_pause_measurement_();
+
+#define PERFSTUBS_RESUME_MEASUREMENT() ps_resume_measurement_();
+
+#define PERFSTUBS_REGISTER_THREAD() ps_register_thread_();
+
+#define PERFSTUBS_DUMP_DATA() ps_dump_data_();
+
+#define PERFSTUBS_TIMER_START(_timer, _timer_name) \
+    static void * _timer = NULL; \
+    if (perfstubs_initialized == PERFSTUBS_SUCCESS) { \
+        if (_timer == NULL) { \
+            _timer = ps_timer_create_(_timer_name); \
+        } \
+        ps_timer_start_(_timer); \
+    };
+
+#define PERFSTUBS_TIMER_STOP(_timer) \
+    if (perfstubs_initialized == PERFSTUBS_SUCCESS) ps_timer_stop_(_timer); \
+
+#define PERFSTUBS_START_STRING(_timer_name) \
+    if (perfstubs_initialized == PERFSTUBS_SUCCESS) { \
+        ps_start_string_(_timer_name); \
+    };
+
+#define PERFSTUBS_STOP_STRING(_timer_name) \
+    if (perfstubs_initialized == PERFSTUBS_SUCCESS) { \
+        ps_stop_string_(_timer_name); \
+    };
+
+#define PERFSTUBS_STOP_CURRENT() \
+    if (perfstubs_initialized == PERFSTUBS_SUCCESS) ps_stop_current_(); \
+
+#define PERFSTUBS_SET_PARAMETER(_parameter, _value) \
+    if (perfstubs_initialized == PERFSTUBS_SUCCESS) ps_set_parameter_(_parameter, _value);
+
+#define PERFSTUBS_DYNAMIC_PHASE_START(_phase_prefix, _iteration_index) \
+    if (perfstubs_initialized == PERFSTUBS_SUCCESS) \
+    ps_dynamic_phase_start_(_phase_prefix, _iteration_index);
+
+#define PERFSTUBS_DYNAMIC_PHASE_STOP(_phase_prefix, _iteration_index) \
+    if (perfstubs_initialized == PERFSTUBS_SUCCESS) \
+    ps_dynamic_phase_stop_(_phase_prefix, _iteration_index);
+
+#define PERFSTUBS_TIMER_START_FUNC(_timer) \
+    static void * _timer = NULL; \
+    if (perfstubs_initialized == PERFSTUBS_SUCCESS) { \
+        if (_timer == NULL) { \
+            char * tmpstr = ps_make_timer_name_(__FILE__, \
+            __PERFSTUBS_FUNCTION__, __LINE__); \
+            _timer = ps_timer_create_(tmpstr); \
+            free(tmpstr); \
+        } \
+        ps_timer_start_(_timer); \
+    };
+
+#define PERFSTUBS_TIMER_STOP_FUNC(_timer) \
+    if (perfstubs_initialized == PERFSTUBS_SUCCESS) ps_timer_stop_(_timer);
+
+#define PERFSTUBS_SAMPLE_COUNTER(_name, _value) \
+    static void * CONCAT(__var,__LINE__) =  NULL; \
+    if (perfstubs_initialized == PERFSTUBS_SUCCESS) { \
+        if (CONCAT(__var,__LINE__) == NULL) { \
+            CONCAT(__var,__LINE__) = ps_create_counter_(_name); \
+        } \
+        ps_sample_counter_(CONCAT(__var,__LINE__), _value); \
+    };
+
+#define PERFSTUBS_METADATA(_name, _value) \
+    if (perfstubs_initialized == PERFSTUBS_SUCCESS) ps_set_metadata_(_name, _value);
+
+#else // defined(PERFSTUBS_USE_TIMERS)
+
+#define PERFSTUBS_INITIALIZE()
+#define PERFSTUBS_FINALIZE()
+#define PERFSTUBS_PAUSE_MEASUREMENT()
+#define PERFSTUBS_RESUME_MEASUREMENT()
+#define PERFSTUBS_REGISTER_THREAD()
+#define PERFSTUBS_DUMP_DATA()
+#define PERFSTUBS_TIMER_START(_timer, _timer_name)
+#define PERFSTUBS_TIMER_STOP(_timer_name)
+#define PERFSTUBS_START_STRING(_timer_name)
+#define PERFSTUBS_STOP_STRING(_timer_name)
+#define PERFSTUBS_STOP_CURRENT()
+#define PERFSTUBS_SET_PARAMETER(_parameter, _value)
+#define PERFSTUBS_DYNAMIC_PHASE_START(_phase_prefix, _iteration_index)
+#define PERFSTUBS_DYNAMIC_PHASE_STOP(_phase_prefix, _iteration_index)
+#define PERFSTUBS_TIMER_START_FUNC(_timer)
+#define PERFSTUBS_TIMER_STOP_FUNC(_timer)
+#define PERFSTUBS_SAMPLE_COUNTER(_name, _value)
+#define PERFSTUBS_METADATA(_name, _value)
+
+#endif // defined(PERFSTUBS_USE_TIMERS)
+
+#ifdef __cplusplus
+
+#if defined(PERFSTUBS_USE_TIMERS)
+
+/*
+ * We allow the namespace to be changed, so that different libraries
+ * can include their own implementation and not have a namespace collision.
+ * For example, library A and executable B could both include the
+ * perfstubs_api code in their source tree, and change the namespace
+ * respectively, instead of linking in the perfstubs library.
+ */
+
+#if defined(PERFSTUBS_NAMESPACE)
+#define PERFSTUBS_INTERNAL_NAMESPACE PERFSTUBS_NAMESPACE
+#else
+#define PERFSTUBS_INTERNAL_NAMESPACE perfstubs_profiler_vtkm
+#endif
+
+#include <memory>
+#include <sstream>
+#include <string>
+
+namespace external
+{
+
+namespace PERFSTUBS_INTERNAL_NAMESPACE
+{
+
+class ScopedTimer
+{
+private:
+    void * m_timer;
+
+public:
+    ScopedTimer(void * timer) : m_timer(timer)
+    {
+        if (perfstubs_initialized == PERFSTUBS_SUCCESS) ps_timer_start_(m_timer);
+    }
+    ~ScopedTimer()
+    {
+        if (perfstubs_initialized == PERFSTUBS_SUCCESS) ps_timer_stop_(m_timer);
+    }
+};
+
+} // namespace PERFSTUBS_INTERNAL_NAMESPACE
+
+} // namespace external
+
+namespace PSNS = external::PERFSTUBS_INTERNAL_NAMESPACE;
+
+#define PERFSTUBS_SCOPED_TIMER(__name) \
+    static void * CONCAT(__var,__LINE__) = ps_timer_create_(__name); \
+    PSNS::ScopedTimer CONCAT(__var2,__LINE__)(CONCAT(__var,__LINE__));
+
+/* The string created by ps_make_timer_name is a memory leak, but
+ * it is only created once per function, since it is called when the
+ * static variable is first initialized. */
+#define PERFSTUBS_SCOPED_TIMER_FUNC() \
+    static void * CONCAT(__var,__LINE__) = \
+        ps_timer_create_(ps_make_timer_name_(__FILE__, \
+        __PERFSTUBS_FUNCTION__, __LINE__)); \
+    PSNS::ScopedTimer CONCAT(__var2,__LINE__)(CONCAT(__var,__LINE__));
+
+#else // defined(PERFSTUBS_USE_TIMERS)
+
+#define PERFSTUBS_SCOPED_TIMER(__name)
+#define PERFSTUBS_SCOPED_TIMER_FUNC()
+
+#endif // defined(PERFSTUBS_USE_TIMERS)
+
+#endif // ifdef __cplusplus

--- a/poincare/vtk-m/examples/poincare/perfstubs_api/tool.h
+++ b/poincare/vtk-m/examples/poincare/perfstubs_api/tool.h
@@ -1,0 +1,129 @@
+// Copyright (c) 2019-2020 University of Oregon
+// Distributed under the BSD Software License
+// (See accompanying file LICENSE.txt)
+
+#pragma once
+#include <stdint.h>
+
+/****************************************************************************/
+/* Declare the structures that a tool should use to return performance data. */
+/****************************************************************************/
+
+typedef struct ps_tool_timer_data
+{
+    unsigned int num_timers;
+    unsigned int num_threads;
+    unsigned int num_metrics;
+    char **timer_names;
+    char **metric_names;
+    double *values;
+} ps_tool_timer_data_t;
+
+typedef struct ps_tool_counter_data
+{
+    unsigned int num_counters;
+    unsigned int num_threads;
+    char **counter_names;
+    double *num_samples;
+    double *value_total;
+    double *value_min;
+    double *value_max;
+    double *value_sumsqr;
+} ps_tool_counter_data_t;
+
+typedef struct ps_tool_metadata
+{
+    unsigned int num_values;
+    char **names;
+    char **values;
+} ps_tool_metadata_t;
+
+/****************************************************************************/
+/* Declare the typedefs of the functions that a tool should implement. */
+/****************************************************************************/
+
+/* Logistical functions */
+typedef void  (*ps_initialize_t)(void);
+typedef void  (*ps_finalize_t)(void);
+typedef void  (*ps_pause_measurement_t)(void);
+typedef void  (*ps_resume_measurement_t)(void);
+typedef void  (*ps_register_thread_t)(void);
+typedef void  (*ps_dump_data_t)(void);
+/* Simple functions */
+typedef void  (*ps_start_string_t)(const char *);
+typedef void  (*ps_stop_string_t)(const char *);
+typedef void  (*ps_stop_current_t)(void);
+/* Data entry functions */
+typedef void* (*ps_timer_create_t)(const char *);
+typedef void  (*ps_timer_start_t)(void *);
+typedef void  (*ps_timer_stop_t)(void *);
+typedef void  (*ps_set_parameter_t)(const char *, int64_t);
+typedef void  (*ps_dynamic_phase_start_t)(const char *, int);
+typedef void  (*ps_dynamic_phase_stop_t)(const char *, int);
+typedef void* (*ps_create_counter_t)(const char *);
+typedef void  (*ps_sample_counter_t)(void *, double);
+typedef void  (*ps_set_metadata_t)(const char *, const char *);
+/* Data Query Functions */
+typedef void  (*ps_get_timer_data_t)(ps_tool_timer_data_t *);
+typedef void  (*ps_get_counter_data_t)(ps_tool_counter_data_t *);
+typedef void  (*ps_get_metadata_t)(ps_tool_metadata_t *);
+typedef void  (*ps_free_timer_data_t)(ps_tool_timer_data_t *);
+typedef void  (*ps_free_counter_data_t)(ps_tool_counter_data_t *);
+typedef void  (*ps_free_metadata_t)(ps_tool_metadata_t *);
+
+/****************************************************************************/
+/* Declare the structure used to register a tool */
+/****************************************************************************/
+
+typedef struct ps_plugin_data {
+    char * tool_name;
+    /* Logistical functions */
+    ps_initialize_t initialize;
+    ps_finalize_t finalize;
+    ps_pause_measurement_t pause_measurement;
+    ps_resume_measurement_t resume_measurement;
+    ps_register_thread_t register_thread;
+    ps_dump_data_t dump_data;
+    /* Simple API */
+    ps_start_string_t start_string;
+    ps_stop_string_t stop_string;
+    ps_stop_current_t stop_current;
+    /* Data entry functions */
+    ps_timer_create_t timer_create;
+    ps_timer_start_t timer_start;
+    ps_timer_stop_t timer_stop;
+    ps_set_parameter_t set_parameter;
+    ps_dynamic_phase_start_t dynamic_phase_start;
+    ps_dynamic_phase_stop_t dynamic_phase_stop;
+    ps_create_counter_t create_counter;
+    ps_sample_counter_t sample_counter;
+    ps_set_metadata_t set_metadata;
+    /* Data Query Functions */
+    ps_get_timer_data_t get_timer_data;
+    ps_get_counter_data_t get_counter_data;
+    ps_get_metadata_t get_metadata;
+    ps_free_timer_data_t free_timer_data;
+    ps_free_counter_data_t free_counter_data;
+    ps_free_metadata_t free_metadata;
+} ps_plugin_data_t;
+
+/****************************************************************************/
+/* Declare the register/deregister weak symbols (implemented by the plugin API
+ * for the registration process */
+/****************************************************************************/
+
+typedef int  (*ps_register_t)(ps_plugin_data_t *);
+typedef void (*ps_deregister_t)(int);
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern __attribute__((weak)) int  ps_register_tool(ps_plugin_data_t * tool);
+extern __attribute__((weak)) void ps_deregister_tool(int tool_id);
+
+#ifdef __cplusplus
+}
+#endif
+
+

--- a/util/cam_timers.hpp
+++ b/util/cam_timers.hpp
@@ -3,8 +3,10 @@
 
 #define TIMER_START(X) GPTLstart(X)
 #define TIMER_STOP(X) GPTLstop(X)
+#define TIMER_DUMP() GPTLdump()
 #else
 #define TIMER_START(X)
 #define TIMER_STOP(X)
+#define TIMER_DUMP()
 #endif
 


### PR DESCRIPTION
These changes add instrumentation to poincare, and add periodic dumping of performance data after each ADIOS step. Please note that the camtimers needed to support the periodic dumping is listed in the README, and the source can be found here: https://github.com/khuck/camtimers